### PR TITLE
fix: rename Filters to HydraFilters for clarity and consistency

### DIFF
--- a/src/TiContent.Foundation.Entities/Storage/StorageEntity.cs
+++ b/src/TiContent.Foundation.Entities/Storage/StorageEntity.cs
@@ -14,7 +14,7 @@ public record StorageEntity
     public record DataBaseTimestampEntity
     {
         public DateTime HydraLinks { get; set; } = DateTime.UnixEpoch;
-        public DateTime Filters { get; set; } = DateTime.UnixEpoch;
+        public DateTime HydraFilters { get; set; } = DateTime.UnixEpoch;
     }
 
     public record UrlsEntity

--- a/src/TiContent.UI.WinUI/Services/DB/DataBaseHydraFiltersService.cs
+++ b/src/TiContent.UI.WinUI/Services/DB/DataBaseHydraFiltersService.cs
@@ -56,7 +56,7 @@ public class DataBaseHydraFiltersService(
         await db.FiltersItems.AddRangeAsync(items, token);
 
         if (storage.Cached != null)
-            storage.Cached.DataBaseTimestamp.Filters = DateTime.Now;
+            storage.Cached.DataBaseTimestamp.HydraFilters = DateTime.Now;
 
         await db.SaveChangesAsync(token);
 
@@ -66,6 +66,6 @@ public class DataBaseHydraFiltersService(
     private bool IsEmptyOrExpiredDataBase()
     {
         return db.FiltersItems.AsNoTracking().IsEmpty()
-            || storage.Obtain().DataBaseTimestamp.HydraLinks < DateTime.Now.AddHours(-3);
+            || storage.Obtain().DataBaseTimestamp.HydraFilters < DateTime.Now.AddHours(-3);
     }
 }

--- a/src/TiContent.UI.WinUI/UI/Pages/FilmsSource/FilmsSourcesPageViewModel.cs
+++ b/src/TiContent.UI.WinUI/UI/Pages/FilmsSource/FilmsSourcesPageViewModel.cs
@@ -308,7 +308,7 @@ public partial class FilmsSourcesPageViewModel
     public record InitialDataEntity(string Query);
 }
 
-// Filters
+// HydraFilters
 
 public partial class FilmsSourcesPageViewModel
 {


### PR DESCRIPTION
Rename all occurrences of Filters to HydraFilters in the codebase to  improve naming clarity and better reflect the data's purpose. Update  property names, comments, and timestamp handling to maintain consistency  across the FilmsSourcesPageViewModel, StorageEntity, and DataBaseHydraFiltersService.